### PR TITLE
Enable setting cache option when defining CouchDB connection

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,24 +4,22 @@ var cradle = require('cradle'),
 
 module.exports.create_connection = function (options) {
   if (typeof(options) === 'string') {
-    logger.info("Connecting to %s",options);   
+    logger.info("Connecting to %s",options);
     db = new (cradle.Connection)().database(options);
-  
+
     return db;
-  }  
-  
+  }
+
   var _options = {},
       db_name = options.db,
       url = options.url,
       port = options.port;
 
   _options.secure = options.secure || false;
-  _options.auth = options.auth;
+  _options.auth   = options.auth;
+  _options.cache  = options.cache === false ?  false : true;
 
-  
-    
   db = new (cradle.Connection)(url,port, _options).database(db_name);
-
 
   return db;
 };


### PR DESCRIPTION
This is essential for scaling out, and starting node is clustered mode.

By default cradle's caching is set to 'true'; if a PUT request is executed in one node and then the same request happens in another node instance. This will cause CouchDB to throw an error because of conflicting revisions, the model didn't get updated in the second instance because the update happened in the first one. 

Setting cache to false and adding another HEAD request fixes this. :)
